### PR TITLE
Fix include list for multiple targets

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -595,7 +595,7 @@ abstract class Target implements IView {
         if (index === -1) {
             configList.push({
                 name: this.cppConfigName,
-                includePath: Array.from(this.includes).concat(['${default},${workspaceFolder}/**']),
+                includePath: Array.from(this.includes).concat(['${default}', '${workspaceFolder}/**']),
                 defines: Array.from(this.defines),
                 intelliSenseMode: '${default}'
             });


### PR DESCRIPTION
When generating a new "c_cpp_properties.json" file, it was combining ${default} and ${workspaceFolder}/** instead of adding them separately.