### PR TITLE
优化compile_commands.json内容，自动生成改为使用命令生成；移除.clangd生成功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,10 @@
           "light": "./res/icons/CopyToClipboard_16x_light.svg",
           "dark": "./res/icons/CopyToClipboard_16x_dark.svg"
         }
+      },
+      {
+        "command": "project.generateCompileCommandsJson",
+        "title": "%keil-assistant.contributes.commands.project-generateCompileCommandsJson%"
       }
     ],
     "menus": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -17,6 +17,7 @@
     "keil-assistant.contributes.commands.project-rebuild.title": "Rebuild",
     "keil-assistant.contributes.commands.project-download.title": "Download To device",
     "keil-assistant.contributes.commands.project-copy.title": "Copy Item Value",
+    "keil-assistant.contributes.commands.project-generateCompileCommandsJson": "Keil uVision Assistant: Generate compile_commands.json(MDK only)",
     "keil-assistant.contributes.conf.props.keil.home.markdownDescription": {
         "message": "Keil uVision (MDK/C51/C251) Installation directory, Please modify the default value according to the actual installation directory, if (MDK/C51/C251) is installed in the same directory, you can set the MDK installation directory separately. \r\n Default value: {\"MDK\":\"C:\\Keil_v5\"}。\r\n\r\nExample:\r\n\r\n\"{\"MDK\":\"C:\\Keil_v5\"}\"\r\n\r\n\"{\"C51\":\"C:\\Keil_v5\"}\"\r\n\r\n\"{\"C251\":\"C:\\Keil_v5\"}\"",
         "comment": [

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -17,6 +17,7 @@
     "keil-assistant.contributes.commands.project-rebuild.title": "重新编译",
     "keil-assistant.contributes.commands.project-download.title": "下载到设备",
     "keil-assistant.contributes.commands.project-copy.title": "复制对像",
+    "keil-assistant.contributes.commands.project-generateCompileCommandsJson": "Keil uVision Assistant: 生成compile_commands.json(仅MDK)",
     "keil-assistant.contributes.conf.props.keil.home.markdownDescription": "Keil uVision (MDK/C51/C251) 安装目录,请根据实际安装目录修改默认值, 如果(MDK/C51/C251)安装在同一目录内，可以单独设置MDK的安装目录即可 \r\n 默认值: {\"MDK\":\"C:\\Keil_v5\"}。\r\n\r\n例子:\r\n\r\n\"{\"MDK\":\"C:\\Keil_v5\"}\"\r\n\r\n\"{\"C51\":\"C:\\Keil_v5\"}\"\r\n\r\n\"{\"C251\":\"C:\\Keil_v5\"}\"",
     "keil-assistant.contributes.viewsWelcome.project.content": "uVision的项目不存在 [了解更多信息](https://github.com/jacksonjim/keil-assistant/blob/master/README.md).\n[打开uVision项目](command:explorer.open)",
     "keil-assistant.contributes.conf.props.project.FindMaxDepth.description": "uVision 项目文件搜索深度,默认为1层子文件夹"

--- a/package.nls.zh-tw.json
+++ b/package.nls.zh-tw.json
@@ -17,6 +17,7 @@
     "keil-assistant.contributes.commands.project-rebuild.title": "重新編譯",
     "keil-assistant.contributes.commands.project-download.title": "下載到設備",
     "keil-assistant.contributes.commands.project-copy.title": "複製專案值",
+    "keil-assistant.contributes.commands.project-generateCompileCommandsJson": "Keil uVision Assistant: 生成compile_commands.json(僅MDK)",
     "keil-assistant.contributes.conf.props.keil.home.markdownDescription": "Keil uVision (MDK/C51/C251) 安裝目錄，請根據實際安裝目錄修改預設值， 如果(MDK/C51/C251)安裝在同一目錄內，可以單獨設置MDK的安裝目錄即可. \r\n 預設值: {\"MDK\":\"C:\\Keil_v5\"}。\r\n\r\n例子:\r\n\r\n\"{\"MDK\":\"C:\\Keil_v5\"}\"\r\n\r\n\"{\"C51\":\"C:\\Keil_v5\"}\"\r\n\r\n\"{\"C251\":\"C:\\Keil_v5\"}\"",
     "keil-assistant.contributes.viewsWelcome.project.content": "uVision的專案不存在 [瞭解更多信息](https://github.com/jacksonjim/keil-assistant/blob/master/README.md).\n[開啟uVision專案](command:explorer.open)",
     "keil-assistant.contributes.conf.props.project.FindMaxDepth.description": "uVision 項目檔搜索深度"

--- a/src/core/KeilProject.ts
+++ b/src/core/KeilProject.ts
@@ -175,8 +175,6 @@ export class KeilProject implements IView, KeilProjectInfo {
         } else {
             this.activeTargetName = this.keilVscodeProps['project']['activeTargetName'];
         }
-
-        this.updateClangdFile();
     }
 
     getInstance(targetDOM: any, rteDom: any): PTarget {
@@ -240,13 +238,8 @@ export class KeilProject implements IView, KeilProjectInfo {
         if (tName !== this.activeTargetName) {
             this.activeTargetName = tName;
             this.updateKeilVscodeProperties();
-            this.updateClangdFile();
             this.notifyUpdateView(); // notify data changed
         }
-    }
-
-    updateClangdFile() {
-        this.getActiveTarget()?.updateClangdFile();
     }
 
     getActiveTarget(): PTarget | undefined {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,6 +88,9 @@ export function activate(context: ExtensionContext) {
         void prjExplorer.statusBarSwitchTargetByProject();
     }));
 
+    subscriber.push(commands.registerCommand('project.generateCompileCommandsJson',
+        (item: IView) => prjExplorer.getTarget(item)?.updateCompileCommands()
+    ));
 
     subscriber.push(myStatusBarItem);
 

--- a/src/target/comm.ts
+++ b/src/target/comm.ts
@@ -1,7 +1,7 @@
 export type CompileCommand = {
+    command: string | undefined,
     directory: string | undefined,
-    file: string | undefined,
-    arguments: string[]
+    file: string | undefined
 }
 
 export type CppProperty = {


### PR DESCRIPTION
- 因为在.clnagd中添加-I(include)参数会影响compile_commands.json的作用。
    - 将.clangd的全部参数移到compile_commands.json中
    - .clangd可以让用户自己根据需要编写。
- 改为使用命令方式生成compile_commands.json，由用户根据需要来生成。
- 不再对库源码屏蔽检查，对库源码检查仍然还有些问题，整体体验还是没问题的。
https://github.com/user-attachments/assets/5e2b04ce-4347-4313-9c7e-cb57c34927dd