### PR TITLE
修改：优化载入工程时添加编译器的include path的识别方式

### DIFF
--- a/src/target/ArmTarget.ts
+++ b/src/target/ArmTarget.ts
@@ -501,11 +501,31 @@ export class ArmTarget extends PTarget {
         }
     }
 */
+    
     protected getSystemIncludes(target: any): string[] | undefined {
+        function extractLastPart(str: string): string {
+            // 1. 找到最后一个 "::" 的位置
+            const lastColonIndex = str.lastIndexOf("::");
+            
+            if (lastColonIndex === -1) {
+                // 如果没有找到 "::"，返回原始字符串（带 trim）
+                return str.trim();
+            }
+            
+            // 2. 提取 "::" 后面的字符串
+            let result = str.substring(lastColonIndex + 2).trim();
+            
+            // 3. 移除开头的 ".\" 前缀（如果存在）
+            if (result.startsWith('.\\')) {
+                result = result.substring(2);
+            }
+            
+            return result;
+        }
         const keilRootDir = new File(ResourceManager.getInstance().getKeilRootDir(this.getKeilPlatform()));
-
         if (keilRootDir.isDir()) {
-            const toolName = target['uAC6'] === 1 ? 'ARMCLANG' : 'ARMCC';
+            // const toolName = target['uAC6'] === 1 ? 'ARMCLANG' : 'ARMCC';
+            const toolName = extractLastPart(target['pCCUsed']);
             const incDir = new File(`${keilRootDir.path}${File.sep}ARM${File.sep}${toolName}${File.sep}include`);
             const incPath = incDir.path.replace(/\\/g, '/');
             if (incDir.isDir()) {


### PR DESCRIPTION
修改前：使用固定的路径获取编译器路径，在keil安装了多个版本的编译器时，无法正常索引到编译器的include文件路径
修改后：通过工程文件的‘pCCUsed’字段获取编译器路径